### PR TITLE
Cleanupprops

### DIFF
--- a/lua/bsu/base/server/pp.lua
+++ b/lua/bsu/base/server/pp.lua
@@ -1,17 +1,11 @@
 -- base/server/pp.lua
 
-local function cleanupProps(id)
-	for _, ent in ipairs(BSU.GetOwnerEntities(id)) do
-		ent:Remove()
-	end
-end
-
 hook.Add("BSU_PlayerBanned", "BSU_CleanupBannedPlayerProps", function(ply)
-	cleanupProps(ply:UserID())
+	BSU.CleanupProps(ply:UserID())
 end)
 
 hook.Add("BSU_PlayerKicked", "BSU_CleanupKickedPlayerProps", function(ply)
-	cleanupProps(ply:UserID())
+	BSU.CleanupProps(ply:UserID())
 end)
 
 hook.Add("PlayerDisconnected", "BSU_HandleDisconnectedPlayerProps", function(ply)
@@ -29,7 +23,7 @@ hook.Add("PlayerDisconnected", "BSU_HandleDisconnectedPlayerProps", function(ply
 
 	-- cleanup after some time
 	timer.Create("BSU_RemoveDisconnected_" .. id, GetConVar("bsu_cleanup_time"):GetFloat(), 1, function()
-		cleanupProps(id)
+		BSU.CleanupProps(ply:UserID())
 	end)
 
 	-- clear permissions granted to disconnected players

--- a/lua/bsu/lib/server/pp.lua
+++ b/lua/bsu/lib/server/pp.lua
@@ -120,3 +120,9 @@ net.Receive("bsu_perms", function(_, ply)
 		end
 	end
 end)
+
+function BSU.CleanupProps(id)
+	for _, ent in ipairs(BSU.GetOwnerEntities(id)) do
+		ent:Remove()
+	end
+end

--- a/lua/bsu/modules/commands/server/moderation.lua
+++ b/lua/bsu/modules/commands/server/moderation.lua
@@ -535,3 +535,18 @@ end)
 hook.Add("PlayerCanHearPlayersVoice", "BSU_PlayerGag", function(_, speaker)
 	if speaker.bsu_gagged then return false end
 end)
+
+BSU.SetupCommand("cleanprops", function(cmd)
+	cmd:SetDescription("Cleans up a player's props")
+	cmd:SetCategory("moderation")
+	cmd:SetAccess(BSU.CMD_ADMIN)
+	cmd:SetFunction(function(self, caller, target)
+
+		BSU.CleanupProps(target:UserID())
+
+		self:BroadcastActionMsg("%caller% cleaned up %target%'s props", {
+			target = target
+		})
+	end)
+	cmd:AddPlayerArg("target", { check = true })
+end)

--- a/lua/bsu/modules/commands/server/moderation.lua
+++ b/lua/bsu/modules/commands/server/moderation.lua
@@ -540,7 +540,7 @@ BSU.SetupCommand("cleanprops", function(cmd)
 	cmd:SetDescription("Cleans up a player's props")
 	cmd:SetCategory("moderation")
 	cmd:SetAccess(BSU.CMD_ADMIN)
-	cmd:SetFunction(function(self, caller, target)
+	cmd:SetFunction(function(self, _, target)
 
 		BSU.CleanupProps(target:UserID())
 


### PR DESCRIPTION
Turns the local `cleanupProps()` function in `base/server/pp.lua` into a library function in `lib/server/pp.lua`, then add a `!cleanprops <player>` command to cleanup a player's props